### PR TITLE
Fix publish workflow trigger; land 0.5.0 version bump

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,7 @@
 name: Publish
 
 on:
-  create:
+  push:
     tags:
       - '*'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "drf-actions"
-version = "0.4.0"
+version = "0.5.0"
 description = "Event journal for Django models powered by native PostgreSQL triggers, with a read-only DRF API"
 authors = [
     "Pavel Maltsev <pavel@speechki.org>",


### PR DESCRIPTION
## Summary
- `on: create` does not support `tags` filters — the filter was silently ignored and Publish ran (and failed) on every branch creation. Switch to `on: push: tags`.
- Cherry-pick the 0.5.0 version bump that was pushed to `pypi-metadata` after PR #13 was already merged, so it never reached master.

After merge, tag `0.5.0` will be recreated on master to publish to PyPI.